### PR TITLE
Add module.exports.getLocale function in translations.js

### DIFF
--- a/core/translations/translations.js
+++ b/core/translations/translations.js
@@ -152,13 +152,21 @@ module.exports.hook = function(func, context = null) {
 
 /**
  * Sets the current locale of the system.
- * @param {string} localeString the string to set the locale to. E.g. 'en' for english.
+ * @param {string} localeString the string to set the locale to. E.g. 'en' for English.
  * @returns {undefined} does not currently return a value.
  */
 module.exports.setLocale = function (localeString) {
     if (localeString) {
         currentLocale = localeString;
     }
+};
+
+/**
+ * Gets the current locale of the system.
+ * @returns {string} returns locale string. E.g. 'en' for English.
+ */
+module.exports.getLocale = function () {
+    return currentLocale;
 };
 
 /**


### PR DESCRIPTION
Add module.exports.getLocale function to let modules get the current locale easily. Also fixed a typo.
I'll need this in the module I'm writing unless there's other, better way of getting current locale I don't know of.