### PR TITLE
Async Core

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,12 @@
         "transform-strict-mode"
     ],
     "presets": [
-        "es2015"
+        ["env", {
+            "targets": {
+                "node": "current"
+            },
+            "useBuiltIns": true
+        }]
     ],
     "retainLines":  true
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
     - osx
 node_js:
     - "4"
-    - "7"
+    - "8"
 before_script:
     - npm install grunt-cli -g
 env:
@@ -33,7 +33,7 @@ deploy:
       on:
         repo: concierge/Concierge
         branch: master
-        node: "7"
+        node: "8"
         condition: "$TRAVIS_OS_NAME = linux"
     - provider: s3
       access_key_id: $AWS_ACCESS_KEY
@@ -47,7 +47,7 @@ deploy:
       on:
         repo: concierge/Concierge
         branch: master
-        node: "7"
+        node: "8"
         condition: "$TRAVIS_OS_NAME = linux"
     - provider: codedeploy
       access_key_id: $AWS_ACCESS_KEY
@@ -61,5 +61,5 @@ deploy:
       on:
         repo: concierge/Concierge
         branch: master
-        node: "7"
+        node: "8"
         condition: "$TRAVIS_OS_NAME = linux"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,15 +7,17 @@ const startConciergeTask = done => {
     }
 
     const concierge = require('./main.js');
-    const platform = concierge({
+    const promise = concierge({
         modules: './modules',
         locale: 'en',
         debug: 'silly',
         timestamp: false,
         loopback: false
     });
-    platform.removeAllListeners('shutdown');
-    platform.once('started', done);
+    promise.then(platform => {
+        platform.removeAllListeners('shutdown');
+        platform.once('started', done);
+    });
 };
 
 module.exports = grunt => {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ const startConciergeTask = done => {
     if (global.currentPlatform) {
         return done();
     }
-
+    process.env.CLONE_TRY_UPSTREAM=1;
     const concierge = require('./main.js');
     const promise = concierge({
         modules: './modules',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,21 +6,9 @@ const startConciergeTask = done => {
         return done();
     }
 
-    const concierge = require('./main.js'),
-        fs = require('fs');
-
-    const moduleDirEmpty = () => {
-        try {
-            return fs.readdirSync('./modules').length <= 0;
-        }
-        catch (e) {
-            return true;
-        }
-    };
-
+    const concierge = require('./main.js');
     const platform = concierge({
         modules: './modules',
-        firstRunInitialisation: moduleDirEmpty(),
         locale: 'en',
         debug: 'silly',
         timestamp: false,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,7 +5,7 @@ const startConciergeTask = done => {
     if (global.currentPlatform) {
         return done();
     }
-    process.env.CLONE_TRY_UPSTREAM=1;
+    process.env.CLONE_TRY_UPSTREAM = '1';
     const concierge = require('./main.js');
     const promise = concierge({
         modules: './modules',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -19,6 +19,7 @@ const startConciergeTask = done => {
 };
 
 module.exports = grunt => {
+    grunt.option('stack', true);
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
         mochaTest: {

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ init:
 environment:
     matrix:
         - nodejs_version: "4"
-        - nodejs_version: "7"
+        - nodejs_version: "8"
 
 platform:
   - x64

--- a/core/common/files.js
+++ b/core/common/files.js
@@ -1,5 +1,6 @@
 ﻿/**
  * Provides helper functions for working with files.
+ * Like fs, but with improvements.
  *
  * Written By:
  *              Matthew Knox
@@ -12,6 +13,26 @@
 const fs = require('fs'),
     path = require('path');
 
+// make promisified version of all callback apis
+for (let m in fs) {
+    if (fs[m + 'Sync']) {
+        exports[m] = (...args) => {
+            return new Promise((resolve, reject) => {
+                fs[m].apply(fs, args.concat((err, ...res) => {
+                    err ? reject(err) : resolve(res.length > 1 ? res : res[0]);
+                }));
+            });
+        };
+    }
+}
+
+/**
+ * Lists all the file system entries in a directory (sync).
+ * @param {string} directory directory to list the file system entries of.
+ * @return {Array<string>} the file system entries in the directory. If the directory
+ * does not exist or there is a problem listing its contents, this will be an empty
+ * array.
+ */
 exports.filesInDirectory = directory => {
     try {
         const files = fs.readdirSync(directory);
@@ -25,6 +46,13 @@ exports.filesInDirectory = directory => {
     }
 };
 
+/**
+ * Delete a directory. Unlike fs.rmdir which will not delete a directory with
+ * content, this method will delete a directory regardless of contents. Does not
+ * follow symlinks.
+ * @param {string} directory the (potentially non-empty) directory to delete.
+ * @param {function()} callback method called on success or failure, (error).
+ */
 exports.deleteDirectory = (directory, callback) => {
     const files = exports.filesInDirectory(directory).map(f => path.join(directory, f));
     const promises = [];
@@ -49,4 +77,36 @@ exports.deleteDirectory = (directory, callback) => {
         fs.chmodSync(directory, 666);
         fs.rmdir(directory, e => callback(e ? (LOG.error(e), e) : null));
     }, () => callback('Error'));
+};
+
+/**
+ * Determines if a file system entry exists, and if it does, what it is.
+ * @param {string} p the path to the file system entry to check.
+ * @returns {string|boolean} false if it doesn't exist, 'directory', 'file' or
+ * 'other' otherwise.
+ */
+exports.existsSync = p => {
+    try {
+        const stat = fs.lstatSync(p);
+        if (stat.isDirectory()) {
+            return 'directory';
+        }
+        if (stat.isFile()) {
+            return 'file';
+        }
+        return 'other';
+    }
+    catch (e) {
+        return false;
+    }
+};
+
+/**
+ * Parses an arbitary JSON file without the overhead of require.
+ * @param {string} file the JSON file to load.
+ * @returns {object} the JSON representation of the file.
+ */
+exports.readJson = async(file) => {
+    const data = await exports.readFile(file, 'utf8');
+    return JSON.parse(data.replace(/^\uFEFF/, ''));
 };

--- a/core/common/files.js
+++ b/core/common/files.js
@@ -11,18 +11,13 @@
  */
 
 const fs = require('fs'),
-    path = require('path');
+    path = require('path'),
+    util = require('util');
 
 // make promisified version of all callback apis
 for (let m in fs) {
     if (fs[m + 'Sync']) {
-        exports[m] = (...args) => {
-            return new Promise((resolve, reject) => {
-                fs[m].apply(fs, args.concat((err, ...res) => {
-                    err ? reject(err) : resolve(res.length > 1 ? res : res[0]);
-                }));
-            });
-        };
+        exports[m] = util.promisify(fs[m]);
     }
 }
 

--- a/core/common/files.js
+++ b/core/common/files.js
@@ -31,7 +31,7 @@ for (let m in fs) {
 exports.filesInDirectory = async(directory) => {
     try {
         const files = await exports.readdir(directory);
-        return files === null ? [] : files;
+        return !files ? [] : files;
     }
     catch (e) {
         return [];

--- a/core/common/files.js
+++ b/core/common/files.js
@@ -49,7 +49,7 @@ exports.deleteDirectory = async(directory) => {
     await Promise.all((await exports.filesInDirectory(directory)).map(async(file) => {
         file = path.join(directory, file);
         try {
-            if (await exports.fileExists(file)) {
+            if (await exports.fileExists(file) === 'directory') {
                 await exports.deleteDirectory(file);
             }
             else {

--- a/core/common/files.js
+++ b/core/common/files.js
@@ -46,7 +46,7 @@ exports.filesInDirectory = async(directory) => {
  * @param {function()} callback method called on success or failure, (error).
  */
 exports.deleteDirectory = async(directory) => {
-    await Promise.all((await exports.filesInDirectory(directory)).forEach(async(file) => {
+    await Promise.all((await exports.filesInDirectory(directory)).map(async(file) => {
         file = path.join(directory, file);
         try {
             if (await exports.fileExists(file)) {
@@ -62,7 +62,6 @@ exports.deleteDirectory = async(directory) => {
             throw (LOG.error(e), e);
         }
     }));
-    await Promise.all(promises);
     await exports.chmod(directory, 666);
     return await exports.rmdir(directory);
 };

--- a/core/common/git.js
+++ b/core/common/git.js
@@ -65,7 +65,7 @@ exports.getCurrentBranchName = async(dir, callback = () => {}) => {
 
 exports.changeBranch = async(dir, branch, callback) => {
     LOG.silly(`Changing branch of "${dir}" to "${branch}".`);
-    return await commandWithPath(dir, ['checkout', branch], callback)
+    return await commandWithPath(dir, ['checkout', branch], callback);
 };
 
 exports.clone = async(url, dir, callback) => {
@@ -74,7 +74,8 @@ exports.clone = async(url, dir, callback) => {
         return clone;
     }
     try {
-        const desiredBranch = `upstream/${(await exports.getCurrentBranchName()).split('/').pop()}`;
+        const currentBranchName = await exports.getCurrentBranchName();
+        const desiredBranch = `upstream/${currentBranchName.split('/').pop()}`;
         await exports.changeBranch(dir, desiredBranch);
     }
     catch (e) {}

--- a/core/common/git.js
+++ b/core/common/git.js
@@ -58,7 +58,7 @@ exports.getCurrentBranchName = async(dir, callback = () => {}) => {
         callback = dir;
         dir = global.__rootPath;
     }
-    const envVars = process.env.TRAVIS_PULL_REQUEST_BRANCH || process.env.TRAVIS_BRANCH || APPVEYOR_REPO_BRANCH;
+    const envVars = process.env.TRAVIS_PULL_REQUEST_BRANCH || process.env.TRAVIS_BRANCH || process.env.APPVEYOR_REPO_BRANCH;
     if (envVars) {
         callback(envVars);
         return envVars;

--- a/core/common/git.js
+++ b/core/common/git.js
@@ -50,8 +50,12 @@ exports.getSHAOfRemoteMaster = async(callback) => {
     return await command(['rev-parse', '--verify', 'origin/master'], callback);
 };
 
-exports.getCurrentBranchName = async(callback) => {
-    return await command(['symbolic-ref', '--short', 'HEAD'], callback);
+exports.getCurrentBranchName = async(dir, callback) => {
+    return await commandWithPath(dir ? dir : global.__rootPath, ['symbolic-ref', '--short', 'HEAD'], dir ? callback : dir);
+};
+
+exports.changeBranch = async(dir, branch, callback) => {
+    return await commandWithPath(dir, ['checkout', branch], callback)
 };
 
 exports.clone = async(url, dir, callback) => {

--- a/core/common/git.js
+++ b/core/common/git.js
@@ -58,7 +58,7 @@ exports.getCurrentBranchName = async(dir, callback = () => {}) => {
         callback = dir;
         dir = global.__rootPath;
     }
-    const envVars = process.env.TRAVIS_PULL_REQUEST_BRANCH || process.env.TRAVIS_BRANCH;
+    const envVars = process.env.TRAVIS_PULL_REQUEST_BRANCH || process.env.TRAVIS_BRANCH || APPVEYOR_REPO_BRANCH;
     if (envVars) {
         callback(envVars);
         return envVars;

--- a/core/common/git.js
+++ b/core/common/git.js
@@ -63,25 +63,15 @@ exports.getCurrentBranchName = async(dir, callback = () => {}) => {
     return await commandWithPath(dir, ['symbolic-ref', '--short', 'HEAD'], callback);
 };
 
-exports.changeBranch = async(dir, branch, callback) => {
-    LOG.silly(`Changing branch of "${dir}" to "${branch}".`);
-    return await commandWithPath(dir, ['checkout', branch], callback);
-};
-
 exports.clone = async(url, dir, callback) => {
-    const clone = await command(['clone', url, dir], callback);
-    if (!process.env.CLONE_TRY_UPSTREAM) {
-        LOG.error('Shouldnt have got here...', process.env.CLONE_TRY_UPSTREAM, !!process.env.CLONE_TRY_UPSTREAM);
-        LOG.critical(new Error());
-        return clone;
-    }
-    try {
+    const args = ['clone', url, dir];
+    if (process.env.CLONE_TRY_UPSTREAM) {
         const currentBranchName = await exports.getCurrentBranchName();
         const desiredBranch = `upstream/${currentBranchName.split('/').pop()}`;
-        await exports.changeBranch(dir, desiredBranch);
+        args.push('-b', desiredBranch);
+        LOG.silly(`Changing checkout branch of "${dir}" to "${desiredBranch}".`);
     }
-    catch (e) {}
-    return clone;
+    return await command(args, callback);
 };
 
 exports.submoduleUpdate = async(callback) => {

--- a/core/common/git.js
+++ b/core/common/git.js
@@ -31,33 +31,33 @@ const exec = require('child_process').exec,
     },
 
     command = async(args, callback) => {
-        await commandWithPath(global.__rootPath, args, callback);
+        return await commandWithPath(global.__rootPath, args, callback);
     };
 
 exports.pull = async(callback) => {
-    await command(['pull'], callback);
+    return await command(['pull'], callback);
 };
 
 exports.pullWithPath = async(path, callback) => {
-    await commandWithPath(path, ['pull'], callback);
+    return await commandWithPath(path, ['pull'], callback);
 };
 
 exports.getSHAOfHead = async(callback) => {
-    await command(['rev-parse', '--verify', 'HEAD'], callback);
+    return await command(['rev-parse', '--verify', 'HEAD'], callback);
 };
 
 exports.getSHAOfRemoteMaster = async(callback) => {
-    await command(['rev-parse', '--verify', 'origin/master'], callback);
+    return await command(['rev-parse', '--verify', 'origin/master'], callback);
 };
 
 exports.getCurrentBranchName = async(callback) => {
-    await command(['symbolic-ref', '--short', 'HEAD'], callback);
+    return await command(['symbolic-ref', '--short', 'HEAD'], callback);
 };
 
 exports.clone = async(url, dir, callback) => {
-    await command(['clone', url, dir], callback);
+    return await command(['clone', url, dir], callback);
 };
 
 exports.submoduleUpdate = async(callback) => {
-    await command(['submodule', 'update', '--init', '--recursive'], callback);
+    return await command(['submodule', 'update', '--init', '--recursive'], callback);
 };

--- a/core/common/git.js
+++ b/core/common/git.js
@@ -71,6 +71,8 @@ exports.changeBranch = async(dir, branch, callback) => {
 exports.clone = async(url, dir, callback) => {
     const clone = await command(['clone', url, dir], callback);
     if (!process.env.CLONE_TRY_UPSTREAM) {
+        LOG.error('Shouldnt have got here...', process.env.CLONE_TRY_UPSTREAM, !!process.env.CLONE_TRY_UPSTREAM);
+        LOG.critical(new Error());
         return clone;
     }
     try {

--- a/core/common/git.js
+++ b/core/common/git.js
@@ -51,7 +51,10 @@ exports.getSHAOfRemoteMaster = async(callback) => {
 };
 
 exports.getCurrentBranchName = async(dir, callback = () => {}) => {
-    if (typeof(dir) === 'function' || typeof(dir) === 'undefined') {
+    if (typeof(dir) === 'undefined') {
+        dir = global.__rootPath;
+    }
+    else if (typeof(dir) === 'function') {
         callback = dir;
         dir = global.__rootPath;
     }
@@ -68,8 +71,13 @@ exports.clone = async(url, dir, callback) => {
     if (process.env.CLONE_TRY_UPSTREAM) {
         const currentBranchName = await exports.getCurrentBranchName();
         const desiredBranch = `upstream/${currentBranchName.split('/').pop()}`;
-        args.push('-b', desiredBranch);
-        LOG.silly(`Changing checkout branch of "${dir}" to "${desiredBranch}".`);
+        try {
+            LOG.silly(`Changing checkout branch of "${dir}" to "${desiredBranch}".`);
+            return await command(args.concat(['-b', desiredBranch]), callback);
+        }
+        catch (e) {
+            LOG.silly('Branch change failed, resorting to HEAD.');
+        }
     }
     return await command(args, callback);
 };

--- a/core/common/git.js
+++ b/core/common/git.js
@@ -50,8 +50,17 @@ exports.getSHAOfRemoteMaster = async(callback) => {
     return await command(['rev-parse', '--verify', 'origin/master'], callback);
 };
 
-exports.getCurrentBranchName = async(dir, callback) => {
-    return await commandWithPath(dir ? dir : global.__rootPath, ['symbolic-ref', '--short', 'HEAD'], dir ? callback : dir);
+exports.getCurrentBranchName = async(dir, callback = () => {}) => {
+    if (typeof(dir) === 'function' || typeof(dir) === 'undefined') {
+        callback = dir;
+        dir = global.__rootPath;
+    }
+    const envVars = process.env.TRAVIS_PULL_REQUEST_BRANCH || process.env.TRAVIS_BRANCH;
+    if (envVars) {
+        callback(envVars);
+        return envVars;
+    }
+    return await commandWithPath(dir, ['symbolic-ref', '--short', 'HEAD'], callback);
 };
 
 exports.changeBranch = async(dir, branch, callback) => {

--- a/core/common/git.js
+++ b/core/common/git.js
@@ -11,52 +11,53 @@
 
 const exec = require('child_process').exec,
 
-    commandWithPath = (path, args, callback) => {
+    commandWithPath = (path, args, callback = () => {}) => {
         args.unshift('git');
         args.forEach((seg, index, arr) => arr[index] = `"${seg}"`);
         const cmd = args.join(' ');
-
-        exec(cmd, {cwd: path}, (error, stdout, stderr) => {
-            stdout = stdout ? stdout.toString() : null;
-            if (error) {
-                if (stderr) {
-                    console.error(stderr.toString());
+        return new Promise((resolve, reject) => {
+            exec(cmd, {cwd: path}, (error, stdout, stderr) => {
+                stdout = stdout ? stdout.toString() : null;
+                if (!error) {
+                    return callback(null, stdout), resolve(stdout);
                 }
-                error.stderr = stderr;
-                return callback(error, stdout);
-            }
-            return callback(null, stdout);
+                if (stderr) {
+                    error.stderr = LOG.error(stderr.toString()), stderr;
+                }
+                error.stdout = stdout;
+                return callback(error, stdout), reject(error);
+            });
         });
     },
 
-    command = (args, callback) => {
-        commandWithPath(global.__rootPath, args, callback);
+    command = async(args, callback) => {
+        await commandWithPath(global.__rootPath, args, callback);
     };
 
-exports.pull = (callback) => {
-    command(['pull'], callback);
+exports.pull = async(callback) => {
+    await command(['pull'], callback);
 };
 
-exports.pullWithPath = (path, callback) => {
-    commandWithPath(path, ['pull'], callback);
+exports.pullWithPath = async(path, callback) => {
+    await commandWithPath(path, ['pull'], callback);
 };
 
-exports.getSHAOfHead = (callback) => {
-    command(['rev-parse', '--verify', 'HEAD'], callback);
+exports.getSHAOfHead = async(callback) => {
+    await command(['rev-parse', '--verify', 'HEAD'], callback);
 };
 
-exports.getSHAOfRemoteMaster = (callback) => {
-    command(['rev-parse', '--verify', 'origin/master'], callback);
+exports.getSHAOfRemoteMaster = async(callback) => {
+    await command(['rev-parse', '--verify', 'origin/master'], callback);
 };
 
-exports.getCurrentBranchName = (callback) => {
-    command(['symbolic-ref', '--short', 'HEAD'], callback);
+exports.getCurrentBranchName = async(callback) => {
+    await command(['symbolic-ref', '--short', 'HEAD'], callback);
 };
 
-exports.clone = (url, dir, callback) => {
-    command(['clone', url, dir], callback);
+exports.clone = async(url, dir, callback) => {
+    await command(['clone', url, dir], callback);
 };
 
-exports.submoduleUpdate = (callback) => {
-    command(['submodule', 'update', '--init', '--recursive'], callback);
+exports.submoduleUpdate = async(callback) => {
+    await command(['submodule', 'update', '--init', '--recursive'], callback);
 };

--- a/core/common/git.js
+++ b/core/common/git.js
@@ -55,11 +55,21 @@ exports.getCurrentBranchName = async(dir, callback) => {
 };
 
 exports.changeBranch = async(dir, branch, callback) => {
+    LOG.silly(`Changing branch of "${dir}" to "${branch}".`);
     return await commandWithPath(dir, ['checkout', branch], callback)
 };
 
 exports.clone = async(url, dir, callback) => {
-    return await command(['clone', url, dir], callback);
+    const clone = await command(['clone', url, dir], callback);
+    if (!process.env.CLONE_TRY_UPSTREAM) {
+        return clone;
+    }
+    try {
+        const desiredBranch = `upstream/${(await exports.getCurrentBranchName()).split('/').pop()}`;
+        await exports.changeBranch(dir, desiredBranch);
+    }
+    catch (e) {}
+    return clone;
 };
 
 exports.submoduleUpdate = async(callback) => {

--- a/core/common/npm.js
+++ b/core/common/npm.js
@@ -9,37 +9,66 @@
  *              Copyright (c) Matthew Knox and Contributors 2017.
  */
 
-const exec = require('child_process').execSync;
+const util = require('util'),
+    childProcess = require('child_process'),
+    execSync = childProcess.execSync,
+    execAsync = util.promisify(childProcess.exec);
 
 /**
  * Executes the provided NPM command(s).
  * @param {Array<string>} args arguments to pass to NPM
  * @param {string} cwd the working directory to operate in. Defaults to the root directory if not provided.
- * @return the stdout output from NPM.
+ * @param {boolean} sync execute the npm command in a synchronous approach.
+ * @return the stdout output from NPM (sync) or a promise (async).
  */
-module.exports = (args, cwd) => {
+module.exports = (args, cwd, sync = false) => {
     if (!cwd) {
         cwd = global.__rootPath;
     }
     args.unshift('npm', '--silent');
-    const res = exec(args.join(' '), { cwd: cwd });
-    return res ? res.toString() : '';
+    if (sync) {
+        const res = execSync(args.join(' '), { cwd: cwd });
+        return res ? res.toString() : '';
+    }
+    return execAsync(args.join(' '), { cwd: cwd });
 };
 
 /**
  * Perform an NPM install in the root directory of the program.
  * @param {Array<string>} args additional arguments to pass to NPM
  * @param {string} cwd working directory, defaults to global.
+ * @return {Promise} a promise representing the npm command.
  */
-module.exports.install = (args, cwd) => {
-    module.exports(['install'].concat(args || []), cwd);
+module.exports.install = async(args, cwd) => {
+    return await module.exports(['install'].concat(args || []), cwd);
+};
+
+/**
+ * Perform an NPM install in the root directory of the program.
+ * @param {Array<string>} args additional arguments to pass to NPM
+ * @param {string} cwd working directory, defaults to global.
+ * @return {string} the stdout of the command.
+ */
+module.exports.installSync = (args, cwd) => {
+    return module.exports(['install'].concat(args || []), cwd, true);
 };
 
 /**
  * Perform an NPM update in the root directory of the program.
  * @param {Array<string>} args additional arguments to pass to NPM
  * @param {string} cwd working directory, defaults to global.
+ * @return {Promise} a promise representing the npm command.
  */
-module.exports.update = (args, cwd) => {
-    module.exports(['update'].concat(args || []), cwd);
+module.exports.update = async(args, cwd) => {
+    return await module.exports(['update'].concat(args || []), cwd);
+};
+
+/**
+ * Perform an NPM update in the root directory of the program.
+ * @param {Array<string>} args additional arguments to pass to NPM
+ * @param {string} cwd working directory, defaults to global.
+ * @return {string} the stdout of the command.
+ */
+module.exports.updateSync = (args, cwd) => {
+    return module.exports(['update'].concat(args || []), cwd, true);
 };

--- a/core/common/npm.js
+++ b/core/common/npm.js
@@ -15,6 +15,7 @@ const exec = require('child_process').execSync;
  * Executes the provided NPM command(s).
  * @param {Array<string>} args arguments to pass to NPM
  * @param {string} cwd the working directory to operate in. Defaults to the root directory if not provided.
+ * @return the stdout output from NPM.
  */
 module.exports = (args, cwd) => {
     if (!cwd) {

--- a/core/common/reddit.js
+++ b/core/common/reddit.js
@@ -9,16 +9,21 @@
  *              Copyright (c) Matthew Knox and Contributors 2017.
  */
 
-const reddit = require('redwrap');
+const reddit = require('redwrap'),
+    util = require('util');
 
-module.exports = exports = (subreddit, numberOfQueries, callback) => {
-    reddit.r(subreddit).limit(numberOfQueries, (err, req) => {
-        if (!err && req && req.data) {
-            callback(false, req.data.children);
-        }
-        else {
-            callback(true, `Well ${subreddit} fell on its face`);
-        }
-    });
+module.exports = exports = async(subreddit, numberOfQueries, callback) => {
+    const limit = util.promisify(reddit.r(subreddit).limit);
+    let req = null, suc = true;
+    try {
+        req = (await limit(numberOfQueries)).data.children;
+    }
+    catch (e) {
+        suc = false;
+    }
+    if (callback) {
+        callback(suc, suc ? req : `Well ${subreddit} fell on its face`);
+    }
+    return req;
 };
 exports.reddit = exports; // backwards compatibility

--- a/core/modules/config.js
+++ b/core/modules/config.js
@@ -155,4 +155,4 @@ class Configuration extends EventEmitter {
     }
 }
 
-module.exports = new Configuration();
+module.exports = Configuration;

--- a/core/modules/config.js
+++ b/core/modules/config.js
@@ -9,7 +9,8 @@
 *              Copyright (c) Matthew Knox and Contributors 2017.
 */
 
-const EventEmitter = require('events');
+const EventEmitter = require('events'),
+    files = require('concierge/files');
 
 const globalScope = {
     name: '%',
@@ -67,7 +68,18 @@ class Configuration extends EventEmitter {
             this.configCache[descriptor.name].force = false;
         }
 
-        const data = this.interceptor ? (await this.interceptor.loadConfig(descriptor)) : {};
+        let data;
+        if (this.interceptor || descriptor !== globalScope) {
+            data = this.interceptor ? (await this.interceptor.loadConfig(descriptor)) : {};
+        }
+        else {
+            try {
+                data = await files.readJson(global.rootPathJoin('config.json'));
+            }
+            catch (e) {
+                data = {};
+            }
+        }
 
         if (this.configCache.hasOwnProperty(descriptor.name)) {
             for (let key of Object.keys(this.configCache[descriptor.name].data)) {

--- a/core/modules/config.js
+++ b/core/modules/config.js
@@ -9,12 +9,12 @@
 *              Copyright (c) Matthew Knox and Contributors 2017.
 */
 
+const EventEmitter = require('events');
+
 const globalScope = {
     name: '%',
     type: ['system']
 };
-
-const EventEmitter = require('events');
 
 class Configuration extends EventEmitter {
     constructor() {
@@ -52,7 +52,7 @@ class Configuration extends EventEmitter {
      * contain a force property to force the next call to load to merge configs.
      * @return {Object} An object representing the configuration.
      */
-    loadConfig(descriptor) {
+    async loadConfig(descriptor) {
         this.emit('preLoad', descriptor);
         if (!descriptor) {
             descriptor = globalScope;
@@ -67,7 +67,7 @@ class Configuration extends EventEmitter {
             this.configCache[descriptor.name].force = false;
         }
 
-        const data = this.interceptor ? this.interceptor.loadConfig(descriptor) : {};
+        const data = this.interceptor ? (await this.interceptor.loadConfig(descriptor)) : {};
 
         if (this.configCache.hasOwnProperty(descriptor.name)) {
             for (let key of Object.keys(this.configCache[descriptor.name].data)) {
@@ -115,8 +115,8 @@ class Configuration extends EventEmitter {
      * @param  {string} section Section of the configuration file to retrieve.
      * @return {Object}         The section, or empty object if undefined.
      */
-    getSystemConfig(section) {
-        const config = this.loadConfig();
+    async getSystemConfig(section) {
+        const config = await this.loadConfig();
         if (config[section] === void(0)) {
             config[section] = {};
         }
@@ -134,7 +134,7 @@ class Configuration extends EventEmitter {
      * (or nothing for global configuration).
      * @return {undefined}    Returns nothing.
      */
-    saveConfig(descriptor) {
+    async saveConfig(descriptor) {
         if (!descriptor) {
             descriptor = globalScope;
         }
@@ -145,7 +145,7 @@ class Configuration extends EventEmitter {
 
         try {
             if (this.interceptor) {
-                this.interceptor.saveConfig(descriptor, this.configCache[descriptor.name].data);
+                await this.interceptor.saveConfig(descriptor, this.configCache[descriptor.name].data);
             }
             delete this.configCache[descriptor.name];
         }

--- a/core/modules/hubot/hubotModule.js
+++ b/core/modules/hubot/hubotModule.js
@@ -11,22 +11,30 @@
 
 const files = require('concierge/files'),
     path = require('path'),
+    reject = 'kassy.json',
     descriptor = 'hubot.json',
     pkg = 'package.json',
     Robot = require('./robot.js');
 
 exports.verifyModule = async(location) => {
     const folderPath = path.resolve(location),
+        ndes = path.join(folderPath, `./${reject}`),
         desc = path.join(folderPath, `./${descriptor}`),
         pack = path.join(folderPath, `./${pkg}`);
+
+    if (await files.fileExists(ndes) === 'file') {
+        return null;
+    }
     let hj;
     if ((await files.fileExists(desc)) === 'file') {
         hj = await files.readJson(desc);
     }
     else {
-        let p;
-        if ((p = await files.fileExists(pack)) && p.main) {
+        let p = {};
+        if (await files.fileExists(pack) === 'file') {
             p = await files.readJson(pack);
+        }
+        if (p.main) {
             hj = Robot.generateHubotJson(folderPath, p.main);
             hj.name = p.name;
             hj.version = p.version;

--- a/core/modules/hubot/hubotModule.js
+++ b/core/modules/hubot/hubotModule.js
@@ -16,16 +16,11 @@ const files = require('concierge/files'),
     Robot = require('./robot.js');
 
 exports.verifyModule = async(location) => {
-    if ((await files.fileExists(location)) !== 'directory')
-        return null;
-    }
-
     const folderPath = path.resolve(location),
         desc = path.join(folderPath, `./${descriptor}`),
         pack = path.join(folderPath, `./${pkg}`);
     let hj;
-
-    if (await files.fileExists(desc)) {
+    if ((await files.fileExists(desc)) === 'file') {
         hj = await files.readJson(desc);
     }
     else {
@@ -43,15 +38,13 @@ exports.verifyModule = async(location) => {
             }
             hj = Robot.generateHubotJson(folderPath, dirFiles[0]);
         }
-        files.writeFile(desc, JSON.stringify(hj, null, 4), 'utf8');
+        await files.writeFile(desc, JSON.stringify(hj, null, 4), 'utf8');
     }
 
     if (!(hj.name && hj.startup && hj.version)) {
         return null;
     }
-    if (!hj.folderPath) {
-        hj.folderPath = folderPath;
-    }
+    hj.folderPath = folderPath;
     if (!hj.type) {
         hj.type = ['module'];
     }

--- a/core/modules/hubot/hubotModule.js
+++ b/core/modules/hubot/hubotModule.js
@@ -16,8 +16,7 @@ const files = require('concierge/files'),
     Robot = require('./robot.js');
 
 exports.verifyModule = async(location) => {
-    const stat = await files.stat(location);
-    if (!stat.isDirectory()) {
+    if ((await files.fileExists(location)) !== 'directory')
         return null;
     }
 
@@ -26,12 +25,12 @@ exports.verifyModule = async(location) => {
         pack = path.join(folderPath, `./${pkg}`);
     let hj;
 
-    if (files.existsSync(desc)) {
+    if (await files.fileExists(desc)) {
         hj = await files.readJson(desc);
     }
     else {
         let p;
-        if ((p = files.existsSync(pack)) && p.main) {
+        if ((p = await files.fileExists(pack)) && p.main) {
             p = await files.readJson(pack);
             hj = Robot.generateHubotJson(folderPath, p.main);
             hj.name = p.name;

--- a/core/modules/kassy/kassyModule.js
+++ b/core/modules/kassy/kassyModule.js
@@ -9,9 +9,9 @@
  *		Copyright (c) Matthew Knox and Contributors 2016.
  */
 
-const fs              = require('fs'),
-    path            = require('path'),
-    descriptor      = 'kassy.json';
+const files = require('concierge/files'),
+    path = require('path'),
+    descriptor = 'kassy.json';
 
 const moduleTypeFunctions = {
     'module': ['run', 'match'],
@@ -19,8 +19,8 @@ const moduleTypeFunctions = {
     'integration': ['start', 'stop', 'getApi']
 };
 
-exports.verifyModule = (location) => {
-    let stat = fs.statSync(location);
+exports.verifyModule = async(location) => {
+    let stat = await files.stat(location);
     if (!stat.isDirectory()) {
         return null;
     }
@@ -28,7 +28,7 @@ exports.verifyModule = (location) => {
     const folderPath = path.resolve(location),
         p = path.join(folderPath, `./${descriptor}`);
     try {
-        stat = fs.statSync(p);
+        stat = await files.stat(p);
         if (!stat) {
             return null;
         }
@@ -37,7 +37,7 @@ exports.verifyModule = (location) => {
         return null;
     }
 
-    const kj = require(p);
+    const kj = await files.readJson(p);
     if (!(kj.name && kj.startup && kj.version !== void(0) && kj.version != null)) {
         return null;
     }

--- a/core/modules/kassy/kassyModule.js
+++ b/core/modules/kassy/kassyModule.js
@@ -42,9 +42,7 @@ exports.verifyModule = async(location) => {
         return null;
     }
 
-    if (!kj.folderPath) {
-        kj.folderPath = folderPath;
-    }
+    kj.folderPath = folderPath;
 
     if (!kj.type) {
         kj.type = 'module';
@@ -53,7 +51,7 @@ exports.verifyModule = async(location) => {
     return kj;
 };
 
-exports.loadModule = (module) => {
+exports.loadModule = module => {
     const modulePath = module.folderPath;
     let startPath   = module.startup,
         m;

--- a/core/modules/kassy/kassyModule.js
+++ b/core/modules/kassy/kassyModule.js
@@ -20,20 +20,10 @@ const moduleTypeFunctions = {
 };
 
 exports.verifyModule = async(location) => {
-    let stat = await files.stat(location);
-    if (!stat.isDirectory()) {
-        return null;
-    }
-
     const folderPath = path.resolve(location),
         p = path.join(folderPath, `./${descriptor}`);
-    try {
-        stat = await files.stat(p);
-        if (!stat) {
-            return null;
-        }
-    }
-    catch (e) {
+
+    if ((await files.fileExists(p)) !== 'file') {
         return null;
     }
 
@@ -47,7 +37,6 @@ exports.verifyModule = async(location) => {
     if (!kj.type) {
         kj.type = 'module';
     }
-
     return kj;
 };
 

--- a/core/modules/modules.js
+++ b/core/modules/modules.js
@@ -367,7 +367,7 @@ class ModuleLoader extends EventEmitter {
     async stopIntegration (integration) {
         integration = this.getModule(integration);
         if (!integration.__descriptor.type.includes('integration') || !integration.__running) {
-            throw new Error('The specified integration is not running.');
+            throw new Error('No such integration exists or the specified integration is not running.');
         }
 
         /**

--- a/core/modules/modules.js
+++ b/core/modules/modules.js
@@ -348,9 +348,9 @@ class ModuleLoader extends EventEmitter {
             const loadedModules = this._loaded[type] ? this._loaded[type].slice() : [];
             return Promise.all(loadedModules.map(mod => this.unloadModule(mod)));
         };
-        const unloadTypes = Object.keys(type).filter(t => t !== 'system').map(t => this._unloadAllModulesOfType(t));
+        const unloadTypes = Object.keys(this._loaded).filter(t => t !== 'system').map(t => _unloadAllModulesOfType(t));
         const results = await Promise.all(unloadTypes);
-        results.push(await this._unloadAllModulesOfType('system')); // force system to be last
+        results.push(await _unloadAllModulesOfType('system')); // force system to be last
         return results;
     }
 

--- a/core/modules/modules.js
+++ b/core/modules/modules.js
@@ -93,7 +93,8 @@ class ModuleLoader extends EventEmitter {
      * @param {string|function()|Object} arg either the name, a filter function to find the module
      * or the module itself (which will just then be returned - useful for argument parsing).
      * @param {string} type the type of module to search for. Defaults to any (null).
-     * @return {Object} the module (if found), array-like otherwise.
+     * @return {Object} the module (if found), array-like otherwise except where the module(s) do
+     * not exist when void(0) will be returned.
      * @emits Platform#started
      */
     getModule (arg, type = null) {
@@ -157,7 +158,7 @@ class ModuleLoader extends EventEmitter {
         this.emit('load', loadEvent);
         if (loadEvent.success && loadEvent.module.load) {
             await this._sleep();
-            loadEvent.module.load(this.platform);
+            await loadEvent.module.load(this.platform);
         }
         return loadEvent;
     }
@@ -229,7 +230,7 @@ class ModuleLoader extends EventEmitter {
         this.emit('prestart', integration);
         try {
             await this._sleep(); // ensure we are not blocking any ongoing operations
-            integration.start((api, event) => {
+            await integration.start((api, event) => {
                 event.event_source = integration.__descriptor.name;
                 this.platform.onMessage(api, event);
             });
@@ -307,7 +308,7 @@ class ModuleLoader extends EventEmitter {
             }
             if (mod.unload) {
                 await this._sleep(); // ensure we are not blocking any ongoing operations
-                mod.unload(mod.platform);
+                await mod.unload(mod.platform);
             }
             await mod.platform.config.saveConfig(descriptor);
             mod.config = null;
@@ -379,7 +380,7 @@ class ModuleLoader extends EventEmitter {
         };
         try {
             await this._sleep(); // ensure we are not blocking any ongoing operations
-            integration.stop();
+            await integration.stop();
             integration.__running = false;
         }
         catch (e) {

--- a/core/modules/modules.js
+++ b/core/modules/modules.js
@@ -168,10 +168,7 @@ class ModuleLoader extends EventEmitter {
      * @param {Array<string>} modules optional list of modules to load.
      */
     async loadAllModules (modules) {
-        const resolvedModules = [],
-            resolvedSystem = [],
-            data = (modules || (await files.filesInDirectory(global.__modulesPath)).map(d => path.join(global.__modulesPath, d)));
-
+        const data = (modules || (await files.filesInDirectory(global.__modulesPath)).map(d => path.join(global.__modulesPath, d)));
         const mods = (await Promise.all(data.map(async(d) => {
             try {
                 const output = await this.verifyModule(path.resolve(d));
@@ -270,9 +267,9 @@ class ModuleLoader extends EventEmitter {
             const spl = mod.version.toString().split('.');
             mod.version = spl.concat(Array(3 - spl.length).fill('0')).join('.');
             switch (mod.priority) {
-                case 'first': mod.priority = Number.MIN_SAFE_INTEGER; break;
-                case 'last': mod.priority = Number.MAX_SAFE_INTEGER; break;
-                default: mod.priority = 0; break;
+            case 'first': mod.priority = Number.MIN_SAFE_INTEGER; break;
+            case 'last': mod.priority = Number.MAX_SAFE_INTEGER; break;
+            default: mod.priority = 0; break;
             }
             mod.__loaderUID = this._loaders.indexOf(l);
             return mod;
@@ -346,7 +343,7 @@ class ModuleLoader extends EventEmitter {
     async unloadAllModules () {
         const _unloadAllModulesOfType = async(type) => {
             const loadedModules = this._loaded[type] ? this._loaded[type].slice() : [];
-            return Promise.all(loadedModules.map(mod => this.unloadModule(mod)));
+            return await Promise.all(loadedModules.map(mod => this.unloadModule(mod)));
         };
         const unloadTypes = Object.keys(this._loaded).filter(t => t !== 'system').map(t => _unloadAllModulesOfType(t));
         const results = await Promise.all(unloadTypes);

--- a/core/modules/modules.js
+++ b/core/modules/modules.js
@@ -216,7 +216,7 @@ class ModuleLoader extends EventEmitter {
             throw new Error(`Integration "${integrationSearchParam.toString()}" ${
                 integration && integration.__running ? 'already started' : 'not found'}.`);
         }
-        LOG.info($$`Loading integration '${integration}'...\t`);
+        LOG.info($$`Loading integration '${integration.__descriptor.name}'...\t`);
         const startEvent = {
             success: true,
             integration: integration
@@ -394,7 +394,7 @@ class ModuleLoader extends EventEmitter {
          * @property {boolean} success - Indicates wheather stopping was successful.
          * @property {object} integration - Integration instance.
          */
-        this.emit('stop', stopObj);
+        this.emit('stop', stopEvent);
         return stopEvent;
     }
 }

--- a/core/modules/modules.js
+++ b/core/modules/modules.js
@@ -184,8 +184,8 @@ class ModuleLoader extends EventEmitter {
             }
         }))).filter(m => !!m);
 
-        const systemMods = mods.filter(m => m.type.contains('system')),
-            normalMods = mods.filter(m => !m.type.contains('system'));
+        const systemMods = mods.filter(m => m.type.includes('system')),
+            normalMods = mods.filter(m => !m.type.includes('system'));
 
         // force system to load first
         await Promise.all(systemMods.map(m => this.loadModule(m)));
@@ -272,6 +272,9 @@ class ModuleLoader extends EventEmitter {
             case 'first': mod.priority = Number.MIN_SAFE_INTEGER; break;
             case 'last': mod.priority = Number.MAX_SAFE_INTEGER; break;
             default: mod.priority = 0; break;
+            }
+            if (!Array.isArray(mod.type)) {
+                mod.type = !!mod.type ? [mod.type] : ['module'];
             }
             mod.__loaderUID = this._loaders.indexOf(l);
             return mod;

--- a/core/modules/modules.js
+++ b/core/modules/modules.js
@@ -204,17 +204,19 @@ class ModuleLoader extends EventEmitter {
 
     /**
      * Starts the specified integration. Integration must be loaded first.
-     * @param {Object|string|function()} integration instance to start. In addion to the integration itself,
-     * this method accepts any of the parameters of the ModuleLoader#getModule method.
+     * @param {Object|string|function()} integrationSearchParam instance to start. In addion to the
+     * integration itself, this method accepts any of the parameters of the ModuleLoader#getModule method.
      * @fires ModuleLoader#prestart
      * @fires ModuleLoader#start
      * @returns {Object} the status of the load request.
      */
-    async startIntegration (integration) {
-        integration = this.getModule(integration);
-        if (!integration.__descriptor.type.includes('integration') || integration.__running) {
-            throw new Error('The specified integration is already running.');
+    async startIntegration (integrationSearchParam) {
+        const integration = this.getModule(integrationSearchParam);
+        if (!integration || !integration.__descriptor.type.includes('integration') || integration.__running) {
+            throw new Error(`Integration "${integrationSearchParam.toString()}" ${
+                integration && integration.__running ? 'already started' : 'not found'}.`);
         }
+        LOG.info($$`Loading integration '${integration}'...\t`);
         const startEvent = {
             success: true,
             integration: integration
@@ -234,7 +236,7 @@ class ModuleLoader extends EventEmitter {
             integration.__running = true;
         }
         catch (e) {
-            LOG.debug(`Integration "${integration.__descriptor.name}" failed to start.`);
+            LOG.debug($$`Failed to start output integration '${integration.__descriptor.name}'.`);
             LOG.critical(e);
             startEvent.success = false;
         }

--- a/core/platform.js
+++ b/core/platform.js
@@ -145,17 +145,12 @@ class Platform extends MiddlewareHandler {
      * @emits Platform#started
      */
     getModule (arg) {
-        const modules = this.modulesLoader.getLoadedModules('module');
-        let func = arg;
-        if (typeof(func) !== 'function') {
-            func = mod => mod.__descriptor.name.trim().toLowerCase() === arg.trim().toLowerCase();
-        }
-        return modules.find(func);
+        return this.modulesLoader.getModule(arg);
     }
 
-    _loadSystemConfig () {
+    async _loadSystemConfig () {
         LOG.warn($$`LoadingSystemConfig`);
-        $$.setLocale(this.config.getSystemConfig('i18n').locale);
+        $$.setLocale((await this.config.getSystemConfig('i18n')).locale);
     }
 
     /**
@@ -179,7 +174,7 @@ class Platform extends MiddlewareHandler {
             for (let integration of integrations) {
                 try {
                     LOG.info($$`Loading integration '${integration}'...\t`);
-                    this.modulesLoader.startIntegration(this.onMessage, integration);
+                    this.modulesLoader.startIntegration(integration);
                 }
                 catch (e) {
                     if (e.message === 'Cannot find integration to start') {
@@ -206,7 +201,7 @@ class Platform extends MiddlewareHandler {
      * @emits Platform#shutdown
      * @see `global.StatusFlag`
      */
-    shutdown (flag) {
+    async shutdown (flag) {
         if (this.statusFlag !== global.StatusFlag.Started) {
             throw new Error($$`ShutdownError`);
         }
@@ -214,7 +209,7 @@ class Platform extends MiddlewareHandler {
         this.emit('preshutdown');
 
         // Unload user modules
-        this.config.saveConfig();
+        await this.config.saveConfig();
         this.modulesLoader.unloadAllModules();
         this.statusFlag = flag || global.StatusFlag.Shutdown;
 

--- a/core/startup/cli.js
+++ b/core/startup/cli.js
@@ -86,7 +86,6 @@ module.exports = cliArgs => {
     }
 
     return {
-        firstRunInitialisation: true,
         integrations: getValue(args.unassociated, ['test'], 'No integrations specified, defaulting to "test".'),
         locale: getValue(args.parsed['-i'], 'en', 'Locale set to "${0}".'),
         debug: getValue(args.parsed['-d'], 'info', 'Log level set to "${0}".'),

--- a/core/startup/exports.js
+++ b/core/startup/exports.js
@@ -74,7 +74,7 @@ module.exports = async(opts) => {
         process.exit(code);
     };
     p.once('shutdown', term);
-    const abort = message => {
+    const abort = async(message) => {
         if (!global.currentPlatform) {
             return;
         }
@@ -82,7 +82,7 @@ module.exports = async(opts) => {
             LOG.warn(message);
         }
         global.currentPlatform.once('shutdown', term);
-        global.currentPlatform.shutdown();
+        await global.currentPlatform.shutdown();
     };
     process.on('SIGINT', abort);
     process.on('SIGHUP', abort.bind(this, 'SIGHUP received. This has an unconditional 10 second terminate time which may not be enough to properly shutdown...'));

--- a/core/startup/exports.js
+++ b/core/startup/exports.js
@@ -20,10 +20,16 @@ const checkType = (obj, key, expectation, ret = false) => {
     return type === expectation;
 };
 
-module.exports = opts => {
+module.exports = async(opts) => {
     opts = opts || {};
-
-    global.$$ = require(rootPathJoin('core/translations/translations.js'));
+    try {
+        global.$$ = require(rootPathJoin('core/translations/translations.js'));
+        await global.$$.init;
+    }
+    catch (e) {
+        LOG.error(e);
+        throw e;
+    }
     if (opts.locale && checkType(opts, 'locale', 'string')) {
         $$.setLocale(opts.locale);
     }

--- a/core/startup/exports.js
+++ b/core/startup/exports.js
@@ -71,8 +71,8 @@ module.exports = async(opts) => {
         throw new Error('An unexpected error occurred during startup.');
     }
     global.currentPlatform = p;
-    p.once('shutdown', () => global.currentPlatform = null);
     const term = code => {
+        global.currentPlatform = null;
         process.removeAllListeners();
         process.exit(code);
     };

--- a/core/startup/exports.js
+++ b/core/startup/exports.js
@@ -50,7 +50,7 @@ module.exports = async(opts) => {
     }
 
     // start platform
-    if (opts.modules || !opts.firstRunInitialisation) {
+    if (opts.modules) {
         if (checkType(opts, 'modules', 'string', true)) {
             global.__modulesPath = path.resolve(opts.modules);
             delete opts.modules;
@@ -62,8 +62,8 @@ module.exports = async(opts) => {
     if (opts.integrations) {
         checkType(opts, 'integrations', 'array');
     }
-    opts.firstRunInitialisation = !!opts.firstRunInitialisation;
-    const p = new Platform(!opts.firstRunInitialisation);
+    global.shim = require(global.rootPathJoin('core/modules/shim.js'));
+    const p = new Platform();
     if (p === null || p === void(0)) {
         throw new Error('An unexpected error occurred during startup.');
     }
@@ -73,9 +73,7 @@ module.exports = async(opts) => {
         process.removeAllListeners();
         process.exit(code);
     };
-    if (opts.firstRunInitialisation) {
-        p.once('shutdown', term);
-    }
+    p.once('shutdown', term);
     const abort = message => {
         if (!global.currentPlatform) {
             return;

--- a/core/startup/exports.js
+++ b/core/startup/exports.js
@@ -61,6 +61,9 @@ module.exports = async(opts) => {
     }
     if (opts.integrations) {
         checkType(opts, 'integrations', 'array');
+        if ((new Set(opts.integrations)).size !== opts.integrations.length) {
+            throw new Error('Cannot start an integration twice.');
+        }
     }
     global.shim = require(global.rootPathJoin('core/modules/shim.js'));
     const p = new Platform();

--- a/core/startup/extensions.js
+++ b/core/startup/extensions.js
@@ -91,7 +91,7 @@ module.exports = (rootPath, direct) => {
 
     // babel and coffee-script setup
     const babylon = require('babylon'),
-        requireInjectionStr = 'require=global.requireHook?global.requireHook(require,__dirname,__filename):require;';
+        requireInjectionStr = 'require = global.requireHook ? global.requireHook(require, __dirname, __filename) : require;';
     require('babel-register')({
         plugins: [{
             visitor: {

--- a/core/startup/extensions.js
+++ b/core/startup/extensions.js
@@ -174,7 +174,7 @@ module.exports = (rootPath, direct) => {
             }
             fn[customPromise] = fn;
             return fn;
-        }
+        };
         util.promisify.custom = customPromise;
     }
 };

--- a/core/startup/extensions.js
+++ b/core/startup/extensions.js
@@ -166,7 +166,7 @@ module.exports = (rootPath, direct) => {
                             orig.apply(this, Array.from(arguments).concat(function () {
                                 const values = Array.from(arguments),
                                     err = values.splice(0, 1);
-                                return err ? reject(err) : resolve(values[0])
+                                return err ? reject(err) : resolve(values[0]);
                             }));
                         }
                         catch (err) {

--- a/core/startup/extensions.js
+++ b/core/startup/extensions.js
@@ -16,6 +16,50 @@ module.exports = (rootPath, direct) => {
         throw new Error('There can be only one instance per process.');
     }
 
+    // util.promisify fallback (needed for node < v8.0.0)
+    const util = require('util');
+    if (!util.promisify) {
+        const customPromise = Symbol('util.promisify.custom');
+        util.promisify = orig => {
+            if (typeof(orig) !== 'function') {
+                const err = TypeError('The "original" argument must be of type function');
+                err.code = 'ERR_INVALID_ARG_TYPE';
+                err.name = `TypeError [${err.code}]`;
+                throw err;
+            }
+
+            let fn = orig[customPromise];
+            if (fn) {
+                if (typeof(fn) !== 'function') {
+                    throw new TypeError('The [util.promisify.custom] property must be a function');
+                }
+            }
+            else {
+                fn = function () {
+                    const temp = Array.from(arguments);
+                    return new Promise((resolve, reject) => {
+                        try {
+                            orig.apply(this, temp.concat(function () {
+                                const values = Array.from(arguments),
+                                    err = values.splice(0, 1)[0];
+                                return err ? reject(err) : resolve(values[0]);
+                            }));
+                        }
+                        catch (err) {
+                            reject(err);
+                        }
+                    });
+                };
+                Object.setPrototypeOf(fn, Object.getPrototypeOf(orig));
+                Object.defineProperties(fn, Object.getOwnPropertyDescriptors(orig));
+                orig[customPromise] = fn;
+            }
+            fn[customPromise] = fn;
+            return fn;
+        };
+        util.promisify.custom = customPromise;
+    }
+
     const path = require('path'),
         cwd = process.cwd();
     // Arbitary location module loading requirements
@@ -46,9 +90,8 @@ module.exports = (rootPath, direct) => {
     };
 
     // babel and coffee-script setup
-    global.requireHook = require(global.rootPathJoin('core/unsafe/require.js'));
     const babylon = require('babylon'),
-        requireInjectionStr = 'require=global.requireHook(require,__dirname,__filename);';
+        requireInjectionStr = 'require=global.requireHook?global.requireHook(require,__dirname,__filename):require;';
     require('babel-register')({
         plugins: [{
             visitor: {
@@ -75,6 +118,7 @@ module.exports = (rootPath, direct) => {
         const res = origcs.apply(this, arguments);
         return requireInjectionStr + res;
     };
+    global.requireHook = require(global.rootPathJoin('core/unsafe/require.js'));
 
     // Prototypes
     String.prototype.toProperCase = function () {
@@ -139,48 +183,5 @@ module.exports = (rootPath, direct) => {
         process.emitWarning = (warning) => {
             console.error(`(node: 56338) Warning: ${warning}`);
         };
-    }
-
-    // util.promisify fallback (needed for node < v8.0.0)
-    const util = require('util');
-    if (!util.promisify) {
-        const customPromise = Symbol('util.promisify.custom');
-        util.promisify = orig => {
-            if (typeof(orig) !== 'function') {
-                const err = TypeError('The "original" argument must be of type function');
-                err.code = 'ERR_INVALID_ARG_TYPE';
-                err.name = `TypeError [${err.code}]`;
-                throw err;
-            }
-
-            let fn = orig[customPromise];
-            if (fn) {
-                if (typeof(fn) !== 'function') {
-                    throw new TypeError('The [util.promisify.custom] property must be a function');
-                }
-            }
-            else {
-                fn = function () {
-                    return new Promise((resolve, reject) => {
-                        try {
-                            orig.apply(this, Array.from(arguments).concat(function () {
-                                const values = Array.from(arguments),
-                                    err = values.splice(0, 1);
-                                return err ? reject(err) : resolve(values[0]);
-                            }));
-                        }
-                        catch (err) {
-                            reject(err);
-                        }
-                    });
-                };
-                Object.setPrototypeOf(fn, Object.getPrototypeOf(orig));
-                Object.defineProperties(fn, Object.getOwnPropertyDescriptors(orig));
-                orig[customPromise] = fn;
-            }
-            fn[customPromise] = fn;
-            return fn;
-        };
-        util.promisify.custom = customPromise;
     }
 };

--- a/core/startup/startup.js
+++ b/core/startup/startup.js
@@ -93,6 +93,7 @@ if (process.env.__concierge_fork) {
         return platform(cli);
     }
     catch (e) {
+        delete e.rawStackTrace;
         console.error(e);
         process.exit(global.currentPlatform ? global.currentPlatform.statusFlag : global.StatusFlag.Unknown);
     }

--- a/core/translations/i18n/en.json
+++ b/core/translations/i18n/en.json
@@ -29,7 +29,7 @@
   "Invalid integration installed (syntax error?).": "Invalid integration installed (syntax error?).",
   "Invalid translation context provided.": "Invalid translation context provided.",
   "Loading integration '${0}'...\t": "Loading integration '${0}'...\t",
-  "Loading module '${0}'... ${1}": "Loading module '${0}'... ${1}",
+  "Loading module '${0}'": "Loading module '${0}'",
   "Loading Succeeded": "Loading Succeeded",
   "Loading the output integration file '${0}' failed.\n\n": "Loading the output integration file '${0}' failed.\n\n",
   "LoadingModules": "Loading modules...",

--- a/core/translations/i18n/hi.json
+++ b/core/translations/i18n/hi.json
@@ -29,7 +29,7 @@
   "Invalid integration installed (syntax error?).": "अवैध इंटीग्रेशन इन्स्टॉल्ड (सिंटेक्स त्रुटि?)",
   "Invalid translation context provided.": "अवैध अनुवाद संदर्भ प्रदान किया है।",
   "Loading integration '${0}'...\t": "'${0}' इंटीग्रेशन लोड हो रही है ...\t",
-  "Loading module '${0}'... ${1}": "'${0}' मॉड्यूल लोड हो रहा है ... ${1}",
+  "Loading module '${0}'": "'${0}' मॉड्यूल लोड हो रहा है",
   "Loading Succeeded": "लोडिंग सफल रही।",
   "Loading the output integration file '${0}' failed.\n\n": "'${0}' आउटपुट इंटीग्रेशन लोड करते हुए असफ़लता हुई।\n\n",
   "LoadingModules": "मॉड्यूल लोड हो रहे है ...",

--- a/core/translations/i18n/pl.json
+++ b/core/translations/i18n/pl.json
@@ -29,7 +29,7 @@
   "Invalid integration installed (syntax error?).": "Nieprawidłowa integracja zainstalowana (błąd składniowy?).",
   "Invalid translation context provided.": "Nieprawidłowy kontekst został dostarczony do tłumaczenia.",
   "Loading integration '${0}'...\t": "Ładowanie integracji '${0}'...\t",
-  "Loading module '${0}'... ${1}": "Ładowanie modułu '${0}'... ${1}",
+  "Loading module '${0}'": "Ładowanie modułu '${0}'",
   "Loading Succeeded": "Ładowanie zakończono pomyślnie",
   "Loading the output integration file '${0}' failed.\n\n": "Ładowanie pliku integracji wyjściowej '${0}' nie powiodło się.\n\n",
   "LoadingModules": "Ładowanie modułów...",

--- a/core/translations/translations.js
+++ b/core/translations/translations.js
@@ -19,7 +19,7 @@ const EventEmitter = require('events'),
 let currentLocale = global.__i18nLocale || defaultLocale;
 
 class TranslatorService extends EventEmitter {
-    constructor (translationsDir) {
+    constructor () {
         super();
         this.hook = null;
         this.translations = {};

--- a/core/translations/translations.js
+++ b/core/translations/translations.js
@@ -11,7 +11,6 @@
 
 const EventEmitter = require('events'),
     path = require('path'),
-    fs = require('fs'),
     files = require('concierge/files'),
     defaultLocale = 'en',
     globalContext = '*',
@@ -31,6 +30,7 @@ class TranslatorService extends EventEmitter {
         const translationFiles = await files.filesInDirectory(translationsDir);
         return await Promise.all(translationFiles.map(async(translationFile) => {
             translationFile = path.join(translationsDir, translationFile);
+            LOG.silly(`Loading translations file at "${translationFile}".`);
             const data = await files.readJson(translationFile);
             return this.translations[path.parse(translationFile).name] = data;
         }));
@@ -183,6 +183,7 @@ module.exports.createContext = async(directory) => {
  */
 module.exports.removeContext = context => {
     if (contextMap.hasOwnProperty(context)) {
+        LOG.silly(`Removing translation context "${context}".`);
         delete contextMap[context];
     }
 };

--- a/core/translations/translations.js
+++ b/core/translations/translations.js
@@ -22,16 +22,17 @@ let currentLocale = global.__i18nLocale || defaultLocale;
 class TranslatorService extends EventEmitter {
     constructor (translationsDir) {
         super();
+        this.hook = null;
         this.translations = {};
         translationsDir = path.resolve(translationsDir);
-        const translationFiles = files.filesInDirectory(translationsDir);
-        for (let i = 0; i < translationFiles.length; i++) {
-            const translationFile = path.join(translationsDir, translationFiles[i]);
-            // avoid using require so we don't have to deal with caching during module unloads...
-            const data = fs.readFileSync(translationFile, 'utf8').replace(/^\uFEFF/, '');
-            this.translations[translationFiles[i].substr(0, translationFiles[i].lastIndexOf('.'))] = JSON.parse(data);
-        }
-        this.hook = null;
+        (async() => {
+            const translationFiles = await files.filesInDirectory(translationsDir);
+            await Promise.all(translationFiles.map(async(translationFile) => {
+                translationFile = path.join(translationsDir, translationFiles[i]);
+                const data = await files.readJson(translationFile);
+                return this.translations[translationFiles[i].substr(0, translationFiles[i].lastIndexOf('.'))] = data;
+            }));
+        });
     }
 
     _fallbackTranslate(strings, values) {

--- a/core/unsafe/logging.js
+++ b/core/unsafe/logging.js
@@ -58,7 +58,7 @@ wrapMethod(console, 'debug');
 wrapMethod(console, 'silly');
 
 global.LOG.title = console.title = args => console.warn(args.white.bold.reset);
-global.LOG.critical = console.critical = args => console.error(args.stack.toString() || args.toString());
+global.LOG.critical = console.critical = args => console.debug(args.stack.toString() || args.toString());
 global.LOG.setLog = console.setLog = enabled => global.LOG[enabled ? 'add' : 'remove'](fileLogger, null, true);
 global.LOG.validateLogLevel = console.validateLogLevel = logLevel => {
     logLevel = logLevel.trim().toLowerCase();

--- a/core/unsafe/require.js
+++ b/core/unsafe/require.js
@@ -147,7 +147,7 @@ const installAndRequire = (req, name, dirName) => {
             endStr = t ? t`Installation complete.` : 'Installation complete.';
 
         console.info(startStr);
-        npm.install([npmName], cwd);
+        npm.installSync([npmName], cwd);
         console.info(endStr);
     }
     else if (nativeReloadHacksCache.hasOwnProperty(name)) {
@@ -211,7 +211,7 @@ module.exports = (req, dirName, fileName) => {
         func[key] = req[key];
     }
 
-    func.forcePackageInstall = dir => {
+    func.forcePackageInstall = async(dir) => {
         const locally = shouldInstallLocally(dir);
         let stat = null;
         try {
@@ -220,7 +220,7 @@ module.exports = (req, dirName, fileName) => {
         catch (e) {}
         try {
             if (global.__runAsLocal && !stat && locally && Object.keys(locally.dependencies).length > 0) {
-                npm.install(Object.keys(locally.dependencies).map(d => `${d}@${locally.dependencies[d]}`), dir);
+                await npm.install(Object.keys(locally.dependencies).map(d => `${d}@${locally.dependencies[d]}`), dir);
             }
         }
         catch (e) {} // ignoring is an ugly solution, but this code *must not fail*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concierge-bot",
-  "version": "4.5.0",
+  "version": "5.0.0",
   "description": "Extensible general purpose chat bot.",
   "main": "main.js",
   "dependencies": {
@@ -28,7 +28,7 @@
     "debug": "node main.js --debug --timestamp"
   },
   "engines": {
-    "node": "6.2.1"
+    "node": "8.0.0"
   },
   "bin": {
     "concierge": "./main.js"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "babel-plugin-transform-strict-mode": "^6.3.13",
     "babel-polyfill": "^6.3.14",
-    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-env": "^1.5.1",
     "babel-register": "^6.3.13",
     "babylon": "^6.8.0",
     "coffee-script": "^1.10.0",

--- a/test/helpers/MockApi.js
+++ b/test/helpers/MockApi.js
@@ -55,6 +55,12 @@ class MockApi extends EventEmitter {
         this.on(event, cb);
     }
 
+    waitForResponseAsync (event = 'message') {
+        return new Promise(resolve => {
+            this.once(event, resolve);
+        });
+    }
+
     getUsers (thread) {
         return this._runMockReturn('getUsers', () => {}, [thread]);
     }

--- a/test/unit/common/files.js
+++ b/test/unit/common/files.js
@@ -7,11 +7,11 @@ const files = c_require('core/common/files.js');
 describe('files', () => {
     describe('#filesInDirectory()', () => {
         it('should not throw an exception on an invalid/empty directory', () => {
-            assert.deepEqual([], files.filesInDirectory('_foobarbaz_'));
+            assert.deepEqual([], await files.filesInDirectory('_foobarbaz_'));
         });
 
         it('should return a list of files in a directory', () => {
-            const f = files.filesInDirectory(__dirname);
+            const f = await files.filesInDirectory(__dirname);
             const known = ['arguments.js', 'files.js', 'git.js', 'middleware.js', 'npm.js', 'reddit.js'];
             for (let file of known) {
                 assert.isTrue(f.includes(file));

--- a/test/unit/common/files.js
+++ b/test/unit/common/files.js
@@ -6,16 +6,18 @@ const files = c_require('core/common/files.js');
 
 describe('files', () => {
     describe('#filesInDirectory()', () => {
-        it('should not throw an exception on an invalid/empty directory', () => {
+        it('should not throw an exception on an invalid/empty directory', async(done) => {
             assert.deepEqual([], await files.filesInDirectory('_foobarbaz_'));
+            done();
         });
 
-        it('should return a list of files in a directory', () => {
+        it('should return a list of files in a directory', async(done) => {
             const f = await files.filesInDirectory(__dirname);
             const known = ['arguments.js', 'files.js', 'git.js', 'middleware.js', 'npm.js', 'reddit.js'];
             for (let file of known) {
                 assert.isTrue(f.includes(file));
             }
+            done();
         });
     });
 });

--- a/test/unit/common/files.js
+++ b/test/unit/common/files.js
@@ -6,18 +6,18 @@ const files = c_require('core/common/files.js');
 
 describe('files', () => {
     describe('#filesInDirectory()', () => {
-        it('should not throw an exception on an invalid/empty directory', async(done) => {
+        it('should not throw an exception on an invalid/empty directory', async() => {
             assert.deepEqual([], await files.filesInDirectory('_foobarbaz_'));
-            done();
+            return true;
         });
 
-        it('should return a list of files in a directory', async(done) => {
+        it('should return a list of files in a directory', async() => {
             const f = await files.filesInDirectory(__dirname);
             const known = ['arguments.js', 'files.js', 'git.js', 'middleware.js', 'npm.js', 'reddit.js'];
             for (let file of known) {
                 assert.isTrue(f.includes(file));
             }
-            done();
+            return true;
         });
     });
 });

--- a/test/unit/common/npm.js
+++ b/test/unit/common/npm.js
@@ -8,7 +8,7 @@ const npm = c_require('core/common/npm.js');
 
 describe('npm', () => {
     describe('exports', () => {
-        it('should not throw an exception', () => {
+        it('should not throw an exception', async(done) => {
             try {
                 npm(['v']);
                 npm(['v'], __dirname);
@@ -16,6 +16,7 @@ describe('npm', () => {
             catch (e) {
                 assert.isTrue(false);
             }
+            done();
         }).timeout(10000);
     });
 });

--- a/test/unit/modules/config.js
+++ b/test/unit/modules/config.js
@@ -2,7 +2,7 @@
 
 const chai = require('chai');
 const assert = chai.assert;
-const ConfigService = new c_require('core/modules/config.js')();
+const ConfigService = new (c_require('core/modules/config.js'))();
 
 // another fairly impossible to test service, due to its dependance on lazy loading the real thing
 

--- a/test/unit/modules/config.js
+++ b/test/unit/modules/config.js
@@ -2,7 +2,7 @@
 
 const chai = require('chai');
 const assert = chai.assert;
-const ConfigService = c_require('core/modules/config.js');
+const ConfigService = new c_require('core/modules/config.js')();
 
 // another fairly impossible to test service, due to its dependance on lazy loading the real thing
 


### PR DESCRIPTION
Please prefix your PR with one of: [WIP], [FEATURE], [FIX], [DOC].

**In raising this pull request, I confirm the following (please check boxes, e.g. [X]):**

- [x] I have reviewed and agree to the Contribution policy of the project.
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request can be closed at the will of a maintainer.
- [x] I give this submission freely, and claim no ownership to its content.

**Changes in this PR:**
This PR aims to fix #248 and drastically decrease the loading time for large numbers of modules.

- Use `babel-preset-env` to enable ES7
- Extend `concierge/files` for full ES7 async `fs`
- Async methods:
    - [X] async `verifyModule(directory)`
    - [X] async `loadAllModules(modules)`
    - [X] async `loadModule(module)`
    - [X] async `startIntegration(integration)`
    - [X] async `stopIntegration(integration)`
    - [X] async `unloadModule(module)`
    - [X] async `unloadAllModules()`

**Still to complete:**  
- [X] `kpm` updates (very small affected surface area due to prior preparation)
- [x] Module contract changes - these were made for architectual reasons and should mean that async-sync changes should have minimal future breaking changes:
    - [X] `files.deleteDirectory`
        - [X] `first-run`
    - [x] `files.filesInDirectory`
        - [x] `boss`
        - [X] `kpm`
    - [X] `reddit` - note that this API change is backwards compatible
        - [X] ~~`pickup`~~ Updating not required
        - [X] ~~`joke`~~ Updating not required
        - [X] ~~`programmer`~~ Updating not required
        - [X] ~~`lolphp`~~ Updating not required
        - [X] ~~`insult`~~ Updating not required
    - [X] `git` - note that this API change is backwards compatible
    - [x] `npm` - note that this API change renamed existing methods to `methodSync`
        - [x] `kpm`
    - [x] `require('concierge-bot')` now returns a promise
        - [X] ~~`GithubConciergeHook`~~ Updating not required
- [x] Other?