### PR TITLE
[FEATURE] Add the ability to run Concierge under Electron node

### DIFF
--- a/core/startup/startup.js
+++ b/core/startup/startup.js
@@ -17,9 +17,24 @@
 
 'use strict';
 
-const fork = require('child_process').fork,
-    path = require('path');
+const cp = require('child_process'),
+	fork = cp.fork,
+    path = require('path'),
+	origSpawn = cp.ChildProcess.prototype.spawn;
 
+cp.ChildProcess.prototype.spawn = function (...args) {
+	const arg0 = args[0];
+	if (arg0 && arg0.envPairs) {
+		const entries = arg0.envPairs.filter(i => i.startsWith('ELECTRON_RUN_AS_NODE'));
+		for (let entry of entries) {
+			const index = arg0.envPairs.indexOf(entry);
+			console.log(`Removing ${entry} at ${index}`);
+			arg0.envPairs.splice(index, 1);
+		}
+	}
+	origSpawn.apply(this, args);
+};
+	
 global.StatusFlag = {
     Unknown: 1,
     NotStarted: 2,

--- a/core/startup/startup.js
+++ b/core/startup/startup.js
@@ -22,7 +22,8 @@ const cp = require('child_process'),
     path = require('path'),
     origSpawn = cp.ChildProcess.prototype.spawn;
 
-cp.ChildProcess.prototype.spawn = function (...args) {
+cp.ChildProcess.prototype.spawn = function () {
+    const args = Array.from(arguments);
     const arg0 = args[0];
     if (arg0 && arg0.envPairs) {
         const entries = arg0.envPairs.filter(i => i.startsWith('ELECTRON_RUN_AS_NODE'));

--- a/core/startup/startup.js
+++ b/core/startup/startup.js
@@ -18,23 +18,22 @@
 'use strict';
 
 const cp = require('child_process'),
-	fork = cp.fork,
+    fork = cp.fork,
     path = require('path'),
-	origSpawn = cp.ChildProcess.prototype.spawn;
+    origSpawn = cp.ChildProcess.prototype.spawn;
 
 cp.ChildProcess.prototype.spawn = function (...args) {
-	const arg0 = args[0];
-	if (arg0 && arg0.envPairs) {
-		const entries = arg0.envPairs.filter(i => i.startsWith('ELECTRON_RUN_AS_NODE'));
-		for (let entry of entries) {
-			const index = arg0.envPairs.indexOf(entry);
-			console.log(`Removing ${entry} at ${index}`);
-			arg0.envPairs.splice(index, 1);
-		}
-	}
-	origSpawn.apply(this, args);
+    const arg0 = args[0];
+    if (arg0 && arg0.envPairs) {
+        const entries = arg0.envPairs.filter(i => i.startsWith('ELECTRON_RUN_AS_NODE'));
+        for (let entry of entries) {
+            const index = arg0.envPairs.indexOf(entry);
+            arg0.envPairs.splice(index, 1);
+        }
+    }
+    origSpawn.apply(this, args);
 };
-	
+
 global.StatusFlag = {
     Unknown: 1,
     NotStarted: 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "concierge-bot",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Extensible general purpose chat bot.",
   "main": "main.js",
   "dependencies": {


### PR DESCRIPTION
**In raising this pull request, I confirm the following (please check boxes, e.g. [X]):**

- [X] I have reviewed and agree to the Contribution policy of the project.
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I have considered, and confirmed that this submission will be valuable to others.
- [X] I accept that this submission may not be used, and the pull request can be closed at the will of a maintainer.
- [X] I give this submission freely, and claim no ownership to its content.

**Changes in this PR:**

Enable use of Electron brand node within Concierge.

This is a monkey patch to spawn (and hence fork) to remove an environment variable which removes the ability to create windows on a forked process. During startup we always fork which means no windows will ever spawn unless we do this (and there is no nicer way to remove the flag, [it is hard coded](https://github.com/electron/node/blob/electron/lib/child_process.js#L102)).
